### PR TITLE
Stores urls as array instead of one long string

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,9 +2,9 @@ browser.storage.local.set({ sessionCounter : 0 });
 
 async function saveSession() {
   let tabs = await browser.tabs.query({currentWindow: true});
-  var sessionTabs = tabs[0].url;
+  var sessionTabs = [];
   for (var i = 1; i < tabs.length; i++) {
-    sessionTabs = sessionTabs + ", " + tabs[i].url;
+    sessionTabs[i] = tabs[i].url;
   }
   var numberOfSavedSessions = browser.storage.local.get("sessionCounter");
   numberOfSavedSessions.then((response)=> {

--- a/sidebar/panel.js
+++ b/sidebar/panel.js
@@ -46,13 +46,11 @@ function onError(error) {
 
 function loadSession(sessionKey) {
   var session = browser.storage.local.get(sessionKey);
-  var tabURLs;
-  session.then((response)=>tabURLs = response[sessionKey].split(", ")).then((response)=>{
+  session.then((response)=>{
+    var tabURLs = response[sessionKey];
     for (var i = 0; i<tabURLs.length; i++) {
       var newTab = browser.tabs.create({url:tabURLs[i]});
       newTab.then(onCreated, onError);
     }
-  }
-
-  );
+  });
 }


### PR DESCRIPTION
Previously urls were concatenated separated by commas and parsed when loaded from storage. Then I realized I could store an array in browser storage. Duh.